### PR TITLE
chore: native Chinese editorial review for v0.5.0

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,7 +32,7 @@ Prompt engineering 改进你对模型说什么。Context engineering 改进模�
 
 本仓库不收录软件事件循环、控制论、增长循环、通用 workflow automation 或非 AI feedback loop。
 
-除资源列表外，本仓库还维护 509 条经过审阅的资源记录，并提供 15 个 loop 模式、15 个经 schema 校验的 loop contracts、6 个可运行的 loop 模板、社区 gallery，以及 8 个语言入口。
+除资源列表外，本仓库还维护 509 条经过审阅的资源记录（canonical sources），并提供 15 个 loop 模式、15 个经 schema 校验的 loop contracts、6 个可运行的 loop 模板、社区 gallery，以及 8 个语言入口。
 
 ## 一句话定位
 

--- a/posts/launch.zh-CN.md
+++ b/posts/launch.zh-CN.md
@@ -27,7 +27,7 @@ Awesome Loop Engineering v0.5.0 聚焦于 prompt、context 与 harness engineeri
 
 Prompt engineering 改善你对模型说什么。Context engineering 改善模型能看到什么。Harness engineering 改善单次运行周围的工具、权限、沙箱和检查。
 
-Loop Engineering 继续追问：什么系统应该定期或按事件启动，发现工作，加载持久上下文，在安全环境中执行，通过明确的 gate 验证，记录 receipts，并决定重复、报告、升级给人或停止？
+Loop Engineering 继续追问：什么系统应该定期或按事件启动，发现工作，加载持久上下文，在安全环境中执行，通过明确的 gate 验证，记录凭证（receipts），并决定重复、报告、升级给人或停止？
 
 目标不是无限自治，而是有边界、可审阅、由证据驱动的重复运行。
 


### PR DESCRIPTION
## 改进说明

对 `README.zh-CN.md` 和 `posts/launch.zh-CN.md` 进行了 native Chinese editorial review。

### 改进内容
1. **README.zh-CN.md**: 在 '资源记录' 后添加 '(canonical sources)' 标注，帮助理解术语
2. **posts/launch.zh-CN.md**: '记录 receipts' → '记录凭证（receipts）'，使中文含义更清晰

### 术语一致性检查
- Loop Engineering, Prompt/Context/Harness engineering, loop contract, schema, agent: 均保留英文 ✓
- canonical source, Resource Atlas, source-line, reduced-motion, canvas diagnostics: 均保留英文 ✓

### 数据一致性检查
- 版本号 v0.5.0、资源 509 条、loop 模式 15、contracts 15、模板 6、语言入口 8：全部一致 ✓
- 所有链接与英文版一致 ✓

### 术语选择说明
保留英文术语以保持技术准确性，避免翻译歧义。在关键术语后添加括号标注辅助理解。